### PR TITLE
Create guest_net_timeout variable.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -232,9 +232,3 @@ variable "email_config" {
   type        = object({ smtp_type = string, from_email = string, mail_server_name = string, mail_server_port = string, auth_username = string, auth_password = string })
   default     = { smtp_type = "SMTP_LOCAL_HOST", from_email = "admin@avicontroller.net", mail_server_name = "localhost", mail_server_port = "25", auth_username = "", auth_password = "" }
 }
-
-variable "guest_net_timeout" {
-	description = "The amount of time to wait for guest networking to become available when deploying the AVI controller OVA."
-	type = number
-	default = 1
-}

--- a/variables.tf
+++ b/variables.tf
@@ -232,3 +232,9 @@ variable "email_config" {
   type        = object({ smtp_type = string, from_email = string, mail_server_name = string, mail_server_port = string, auth_username = string, auth_password = string })
   default     = { smtp_type = "SMTP_LOCAL_HOST", from_email = "admin@avicontroller.net", mail_server_name = "localhost", mail_server_port = "25", auth_username = "", auth_password = "" }
 }
+
+variable "guest_net_timeout" {
+	description = "The amount of time to wait for guest networking to become available when deploying the AVI controller OVA."
+	type = number
+	default = 1
+}

--- a/vsphere-vm.tf
+++ b/vsphere-vm.tf
@@ -77,7 +77,6 @@ resource "vsphere_virtual_machine" "avi_controller" {
       "default-gw" = var.controller_gateway
     }
   }
-  wait_for_guest_net_timeout = "1"
   provisioner "local-exec" {
     command = "bash ${path.module}/files/change-controller-password.sh --controller-address \"${var.controller_ip[count.index]}\" --current-password \"${var.controller_default_password}\" --new-password \"${var.controller_password}\""
   }

--- a/vsphere-vm.tf
+++ b/vsphere-vm.tf
@@ -77,7 +77,7 @@ resource "vsphere_virtual_machine" "avi_controller" {
       "default-gw" = var.controller_gateway
     }
   }
-  wait_for_guest_net_timeout = "1"
+  wait_for_guest_net_timeout = var.guest_net_timeout
   provisioner "local-exec" {
     command = "bash ${path.module}/files/change-controller-password.sh --controller-address \"${var.controller_ip[count.index]}\" --current-password \"${var.controller_default_password}\" --new-password \"${var.controller_password}\""
   }

--- a/vsphere-vm.tf
+++ b/vsphere-vm.tf
@@ -77,7 +77,7 @@ resource "vsphere_virtual_machine" "avi_controller" {
       "default-gw" = var.controller_gateway
     }
   }
-  wait_for_guest_net_timeout = var.guest_net_timeout
+  wait_for_guest_net_timeout = "1"
   provisioner "local-exec" {
     command = "bash ${path.module}/files/change-controller-password.sh --controller-address \"${var.controller_ip[count.index]}\" --current-password \"${var.controller_default_password}\" --new-password \"${var.controller_password}\""
   }


### PR DESCRIPTION
When using this module to deploy within our infrastructure we
encountered time out errors while waiting on the deployment of the AVI
appliances.

Increasing the value of the wait_for_guest_net_timeout attribute of the
vsphere_virtual_machine.avi_controller resource from the default value
of 1 to 2 solved this problem for us.

This change introduces the guest_net_timeout variable to the module with
to allow this attribute to be configured on a case-by-case basis.  The
default value is still 1.