### PR TITLE
Make se_mgmt_portgroup optional.

### DIFF
--- a/files/avi-vsphere-all-in-one-play.yml.tpl
+++ b/files/avi-vsphere-all-in-one-play.yml.tpl
@@ -21,7 +21,9 @@
     vsphere_user: ${vsphere_user}
     vsphere_server: ${vsphere_server}
     vm_datacenter: ${vm_datacenter}
+	%{ if configure_se_mgmt_network ~}
     se_mgmt_portgroup: ${se_mgmt_portgroup}
+	%{ endif ~}
     dns_search_domain: ${dns_search_domain}
     ansible_become: yes
     ansible_become_password: "{{ password }}"

--- a/files/avi-vsphere-all-in-one-play.yml.tpl
+++ b/files/avi-vsphere-all-in-one-play.yml.tpl
@@ -21,9 +21,9 @@
     vsphere_user: ${vsphere_user}
     vsphere_server: ${vsphere_server}
     vm_datacenter: ${vm_datacenter}
-	%{ if configure_se_mgmt_network ~}
+%{ if configure_se_mgmt_network ~}
     se_mgmt_portgroup: ${se_mgmt_portgroup}
-	%{ endif ~}
+%{ endif ~}
     dns_search_domain: ${dns_search_domain}
     ansible_become: yes
     ansible_become_password: "{{ password }}"


### PR DESCRIPTION
The ansible playbook generated by the template
files/avi-vsphere-all-in-one-play.yml.tpl expects the value of
se_mgmt_portgroup to not be null even when we do not intend to configure
the se_mgmt_network.  This change removes that variable from the
generated playbook when configure_se_mgmt_network is false.